### PR TITLE
how-to-contribute-content sync repo 오타 수정 

### DIFF
--- a/content/post/hugo-intro/how-to-contribute-content.md
+++ b/content/post/hugo-intro/how-to-contribute-content.md
@@ -88,7 +88,7 @@ Pull Request에 대한 자세한 내용은 [GitHub의 도움말](https://help.gi
 ```
 # Add the remote, call it "upstream":
 
-git remote add upstream https://github.com/golangkorea/golangkorea.git
+git remote add upstream https://github.com/golangkorea/golangkorea-hugo.git
 
 # Fetch all the branches of that remote into remote-tracking branches,
 # such as upstream/master:


### PR DESCRIPTION
#15 건을 해결합니다.
- git sync repo 주소 오타 수정

```
최신의 golankorea-hugo repo와 싱크하기
```
